### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -226,9 +226,7 @@ fn handle_request(config: &Config, request: &Request) -> String {
 }
 
 fn named_children<'a>(node: &'a Node) -> impl Iterator<Item = Node<'a>> {
-    (0..node.child_count())
-        .into_iter()
-        .map(move |i| node.child(i).unwrap())
+    (0..node.child_count()).map(move |i| node.child(i).unwrap())
 }
 
 fn select_ranges(buffer: &[String], ranges: &[Range]) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,3 @@
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
-
 use clap::{crate_version, App, Arg};
 use fnv::FnvHashMap;
 use itertools::Itertools;


### PR DESCRIPTION
For the macro thing, you don't need `extern crate` for crates listed in `Cargo.toml`. To use macros defined in a crate, you have to `use` them like any other symbol:

    use slog::info;

For the `.into_iter()` thing, apparently a `Range` already implements `Iterator`, so it doesn't need to be converted into one.