### PR TITLE
Simplify the SelectChildren operation.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -210,15 +210,10 @@ fn handle_request(config: &Config, request: &Request) -> String {
         Op::SelectChildren => {
             for range in &ranges {
                 let node = find_range_superset_deepest_node(&tree, range);
-                let node = traverse_up_to_node_which_matters(filetype_config, node);
-                if node.named_child_count() > 0 {
-                    for child in named_children(&node) {
-                        if node_matters(filetype_config, child.kind()) {
-                            new_ranges.push(child.range());
-                        }
+                for child in named_children(&node) {
+                    if node_matters(filetype_config, child.kind()) {
+                        new_ranges.push(child.range());
                     }
-                } else {
-                    new_ranges.push(node.range());
                 }
             }
             select_ranges(&buffer, &new_ranges)


### PR DESCRIPTION
We remove `traverse_up_to_node_which_matters()` because if we have multiple selections (such as from a previous invocation of SelectChildren) that ensures we select the children of the node containing all the selections, rather than the children of each selection.

We remove the code to preserve selected nodes with no children. Those are typically keywords and delimiting punctuation; if the user invokes SelectChildren on an array literal, they probably want to work with each item rather than with the brackets and commas. Also, this change makes SelectNode and SelectChildren into opposites. Previously, after invoking SelectChildren any number of times, invoking SelectNode once would return to the initial selection, because some direct child of the initial node would still be selected. Now if you SelectChildren three times, you'll probably have to SelectNode three times to get back, which makes more sense.

This change doesn't strictly require #1 to be merged first, but it expects it.