### PR TITLE
add Elm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -78,3 +78,6 @@
 	path = vendor/tree-sitter-julia
 	url = https://github.com/tree-sitter/tree-sitter-julia.git
 	shallow = true
+[submodule "vendor/tree-sitter-elm"]
+	path = vendor/tree-sitter-elm
+	url = https://github.com/Razzeee/tree-sitter-elm.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ all = [
     "c",
     "cpp",
     "css",
+    "elm",
     "go",
     "haskell",
     "html",
@@ -48,6 +49,7 @@ c_sharp = []
 c = []
 cpp = []
 css = []
+elm = []
 go = []
 haskell = []
 html = []

--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,8 @@ fn main() {
         "cpp",
         #[cfg(feature = "css")]
         "css",
+        #[cfg(feature = "elm")]
+        "elm",
         #[cfg(feature = "go")]
         "go",
         #[cfg(feature = "haskell")]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -11,6 +11,8 @@ extern "C" {
     fn tree_sitter_cpp() -> Language;
     #[cfg(feature = "css")]
     fn tree_sitter_css() -> Language;
+    #[cfg(feature = "elm")]
+    fn tree_sitter_elm() -> Language;
     #[cfg(feature = "go")]
     fn tree_sitter_go() -> Language;
     #[cfg(feature = "haskell")]
@@ -53,6 +55,8 @@ pub fn filetype_to_language(filetype: &str) -> Option<Language> {
         "cpp" => tree_sitter_cpp,
         #[cfg(feature = "css")]
         "css" => tree_sitter_css,
+        #[cfg(feature = "elm")]
+        "elm" => tree_sitter_elm,
         #[cfg(feature = "go")]
         "go" => tree_sitter_go,
         #[cfg(feature = "haskell")]


### PR DESCRIPTION
this adds elm via Razzeee/tree-sitter-elm

I'm not sure if this works now, TBQH… I can substitute the binary in a running `kak` instance by using `set-config`, but then calling the selection functions doesn't seem to work. I tried adding `-vvv` as mentioned in `rc/tree.kak` but I'm not sure where the output ends up. Any ideas what I can do to debug?