### PR TITLE
enable clojure compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,8 @@ fn main() {
         "c-sharp",
         #[cfg(feature = "c")]
         "c",
+        #[cfg(feature = "clojure")]
+        "clojure",
         #[cfg(feature = "cpp")]
         "cpp",
         #[cfg(feature = "css")]


### PR DESCRIPTION
Fixes prior issue with clojure compilation, allowing for 'all' features to be built.
c.f. issue #23   